### PR TITLE
Fix problem querying playbook status with ansible runner V.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ addons:
 
 cache: pip
 
-branches:
-  only:
-  - master
-
 before_install:
     - sudo apt-add-repository --yes ppa:ansible/ansible
     - sudo apt-get update

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible_runner>=1.1.1
+ansible_runner==1.3.0
 crypto
 paramiko
 PyYAML

--- a/runner_service/services/jobs.py
+++ b/runner_service/services/jobs.py
@@ -101,8 +101,11 @@ def event_summary(event_info, summary_keys=['host', 'task', 'role', 'event']):
 
     if summary_keys:
         base = {k: event_info[k] for k in summary_keys if k in event_info}
-        event_data = {k: event_info['event_data'][k] for k in summary_keys
-                      if k in event_info.get('event_data')}
+
+        event_data = {}
+        if 'event_data' in event_info:
+            event_data = {k: event_info['event_data'][k] for k in summary_keys
+                          if k in event_info.get('event_data')}
 
         # python3.5 an above idiom
         # return {**base, **event_data}

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -101,10 +101,12 @@ def cb_playbook_finished(runner):
     :param runner:  instance of ansible_runner.Runner for the playbook that has
                     just completed
     """
+
     logger.info("Playbook {}, UUID={} ended, "
                 "status={}".format(runner.config.playbook,
                                    runner.config.ident,
                                    runner.status))
+
     try:
         stats = runner.stats
     except AnsibleRunnerException as err:
@@ -136,6 +138,7 @@ def prune_runner_cache(current_runner):
 
 
 def cb_event_handler(event_data):
+    logger.debug("cb_event_handler event_data={}".format(event_data))
 
     # first look at the event to track overall stats in the runner_stats object
     event_type = event_data.get('event', None)
@@ -157,7 +160,13 @@ def cb_event_handler(event_data):
             runner_cache[ident]['current_task_metadata'] = metadata
 
         runner_cache[ident]['last_task_num'] = event_data['counter']
-        runner_cache[ident]['role'] = event_data['event_data'].get('role', '')
+
+        # role is not a fixed attribute
+        role_value = ''
+        if 'role' in event_data:
+            role_value =  runner_cache[ident]['role'] = event_data['event_data'].get('role', '') # noqa
+        runner_cache[ident]['role'] = role_value
+
         if event_type.startswith("runner_on_"):
             event_shortname = event_type[10:]
             if event_shortname in runner_cache[ident]:


### PR DESCRIPTION
It seems that one of the "event_data" attributes, "role" is not provided. I have avoid a "unlogged" and "hidden" error if this situation happens.

Apart of this, i have set a fixed version of "ansible runner" as requirement (1.3.0). This will avoid that other updates in ansible runner cause unexpected behaviour in the Ansible Runner Service. 
This also will force us to pass u.t. if we want to update the ansible runner version. 

Solves: https://github.com/ansible/ansible-runner-service/issues/10