### PR TITLE
Update Ansible Version

### DIFF
--- a/misc/nginx/Dockerfile
+++ b/misc/nginx/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 
 # Install dependencies
 RUN yum -y install epel-release  && \
-    yum -y install bash wget unzip ansible-2.7.10 \
+    yum -y install bash wget unzip \
            pexpect python-daemon  bubblewrap gcc \
            bzip2  openssh openssh-clients python2-psutil\
            python36 python36-devel python36-setuptools\
@@ -11,7 +11,7 @@ RUN yum -y install epel-release  && \
 RUN easy_install-3.6 -d /usr/lib/python3.6/site-packages pip && \
     ln -s /usr/lib/python3.6/site-packages/pip3 /usr/local/bin/pip3
 
-RUN /usr/local/bin/pip3 install crypto docutils psutil paramiko PyYAML \
+RUN /usr/local/bin/pip3 install ansible crypto docutils psutil paramiko PyYAML \
                  pyOpenSSL flask flask-restful uwsgi netaddr notario && \
     /usr/local/bin/pip3 install --no-cache-dir ansible-runner==1.3.2 && \
     rm -rf /var/cache/yum


### PR DESCRIPTION
Installing Ansible using pip3.

- This forces Ansible to run Python3. (installing with yum Python 2 is used)
- In this way we have the last version of Ansible Available (2.8.1). (compatibility risk with Ansible Runner)

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>