### PR TITLE
Dockerfile improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,20 +22,21 @@ RUN mkdir -p /etc/ansible-runner-service && \
     mkdir -p /usr/share/ansible-runner-service/{artifacts,env,project,inventory,client_cert}
 
 # Install Ansible Runner
-COPY ./ansible-runner-service.tar.gz /root/.
 WORKDIR /root
-RUN tar xvzf ansible-runner-service.tar.gz
-RUN rm ansible-runner-service.tar.gz
+COPY ./*.py ansible-runner-service/
+COPY ./*.yaml ansible-runner-service/
+COPY ./runner_service ansible-runner-service/runner_service
+COPY ./samples ansible-runner-service/samples
 
 # Put configuration files in the right places
 # Nginx configuration
-COPY ./nginx.conf /etc/nginx/
+COPY misc/nginx/nginx.conf /etc/nginx/
 # Ansible Runner Service nginx virtual server
-COPY ./ars_site_nginx.conf /etc/nginx/conf.d
+COPY misc/nginx/ars_site_nginx.conf /etc/nginx/conf.d
 # Ansible Runner Service uwsgi settings
-COPY ./uwsgi.ini /root/ansible-runner-service
+COPY misc/nginx/uwsgi.ini /root/ansible-runner-service
 # Supervisor start sequence
-COPY ./supervisord.conf /root/ansible-runner-service
+COPY misc/nginx/supervisord.conf /root/ansible-runner-service
 
 # Start services
 CMD ["/usr/bin/supervisord", "-c", "/root/ansible-runner-service/supervisord.conf"]

--- a/Dockerfile.python27
+++ b/Dockerfile.python27
@@ -15,20 +15,21 @@ RUN mkdir -p /etc/ansible-runner-service && \
     mkdir -p /usr/share/ansible-runner-service/{artifacts,env,project,inventory,client_cert}
 
 # Install Ansible Runner Service
-COPY ./ansible-runner-service.tar.gz /root/.
 WORKDIR /root
-RUN tar xvzf ansible-runner-service.tar.gz
-RUN rm -rf ansible-runner-service.tar.gz
+COPY ./*.py ansible-runner-service/
+COPY ./*.yaml ansible-runner-service/
+COPY ./runner_service ansible-runner-service/runner_service
+COPY ./samples ansible-runner-service/samples
 
 # Put configuration files in the right places
 # Nginx configuration
-COPY ./nginx.conf /etc/nginx/
+COPY misc/nginx/nginx.conf /etc/nginx/
 # Ansible Runner Service nginx virtual server
-COPY ./ars_site_nginx.conf /etc/nginx/conf.d
+COPY misc/nginx/ars_site_nginx.conf /etc/nginx/conf.d
 # Ansible Runner Service uwsgi settings
-COPY ./uwsgi.ini /root/ansible-runner-service
+COPY misc/nginx/uwsgi.ini /root/ansible-runner-service
 # Supervisor start sequence
-COPY ./supervisord.conf /root/ansible-runner-service
+COPY misc/nginx/supervisord.conf /root/ansible-runner-service
 
 # Start services
 CMD ["/usr/bin/supervisord", "-c", "/root/ansible-runner-service/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ ansible_runner_service
 ```
 ## Production ready container
 
-A container suitable for production systems can be build using the dockerfile present in <misc/nginx> folder. It uses nginx with mutual TLS authentication to provide the Ansible Runner Service API.
+A container suitable for production systems can be build using the 'Dockerfile' present in the project root folder. It uses nginx with mutual TLS authentication to provide the Ansible Runner Service API.
 
 Check documentation in <misc/nginx/README.md> folder for more information.
 

--- a/misc/nginx/README.md
+++ b/misc/nginx/README.md
@@ -19,9 +19,8 @@ The provided container uses CentOS with Python 3.6 (most of the development work
 
 ## Local Preparation
 1. download the project to your home directory and untar/unzip
-2. create an archive of the project called ansible-runner-service.tar.gz and
-store it in the misc/docker directory
-3. set up you local environment to persist the config
+
+2. set up you local environment to persist the config
 ```
  sudo mkdir /etc/ansible-runner-service
  sudo mkdir -p /usr/share/ansible-runner-service/{artifacts,env,inventory,project}
@@ -108,11 +107,7 @@ Double check that the rights for this files allow their utilization in the clien
 
 
 ## Building (as root, or use sudo)
-1. from the ansible-runner-service directory
-```
-cd misc/nginx
-```
-2. Build the container
+1. From the ansible-runner-service directory build the container
 ```
 docker build -f Dockerfile -t runner-service .
 ```


### PR DESCRIPTION
- Avoid to use a tar.gz for the source.
This prevented to use registry automatic builds. Now when we will merge changes to master the DockerHub image will be rebuilt automatically.

- Moved Dockerfiles to ease container builds.
To right place for the "Dockerfile" is the root folder of the project. To use other child folder implies to use docker compose or other weird tricks to collect source files from parent folders.
So i have moved the Docker files used for build the production container to the project root folder 

- Updated documentation to reflect these changes

- Py36 version of the container tested locally.