### PR TITLE
New spec file to install without dependencies

### DIFF
--- a/misc/packaging/README
+++ b/misc/packaging/README
@@ -26,3 +26,9 @@ CentOS7
 
 Resulting RPM Tested Against
 - CentOS 7.4, Python 2.7.5
+
+
+Container build
+
+The <ars_source.spec> file allows to produce an rpm to install Ansible Runner Service without any dependency.
+This is specially suited for use in containers where the dependencies are going to be especified directly in the Dockerfile.

--- a/misc/packaging/ars_source.spec
+++ b/misc/packaging/ars_source.spec
@@ -13,24 +13,14 @@ License: ASL 2.0
 
 BuildArch: noarch
 
-BuildRequires: python-setuptools
-BuildRequires: python-devel
-
-Requires: ansible >= 2.8.1
-Requires: ansible-runner = 1.3.2
-Requires: python-flask >= 1.0.2
-Requires: python2-flask-restful >= 0.3.5
-Requires: python2-crypto
-Requires: python-paramiko
-Requires: openssl
-Requires: pyOpenSSL
-Requires: PyYAML
-Requires: python-jwt
 
 %description
-This package provides a daemon that exposes a REST API interface on top of the functionality provided by ansible and ansible_runner.
+This package provides the Ansible Runner Service source files. Ansible runner service exposes a REST API interface on top of the functionality provided by ansible and ansible_runner.
 
-The daemon (ansible-runner-service) listens on https://localhost:5001 by default for playbook or ansible inventory requests. For developers interested in using the API, all the available endpoints are documented at https://localhost:5001/api.
+The Ansible Runner Service provided in this packages is intended to be used as uwgsi app exposed by Nginx in a Container.
+Dependencies, and configuration tasks must be performed in the container.
+
+Ansible Runner Service listens on https://localhost:5001 by default for playbook or ansible inventory requests. For developers interested in using the API, all the available endpoints are documented at https://localhost:5001/api.
 
 In addition to the API endpoints, the daemon also provides a /metrics endpoint for prometheus integration. A sample Grafana dashboard is provided within /usr/share/doc/ansible-runner-service
 
@@ -61,11 +51,10 @@ install -m 0644 ./misc/dashboards/ansible-runner-service-metrics.json  %{buildro
 install -m 0644 ./LICENSE.md %{buildroot}%{_docdir}/ansible-runner-service
 
 %post
-/bin/systemctl --system daemon-reload &> /dev/null || :
-/bin/systemctl --system enable --now ansible-runner-service &> /dev/null || :
+
 
 %postun
-/bin/systemctl --system daemon-reload &> /dev/null || :
+
 
 %files
 %{_bindir}/ansible_runner_service
@@ -76,9 +65,5 @@ install -m 0644 ./LICENSE.md %{buildroot}%{_docdir}/ansible-runner-service
 %{_docdir}/ansible-runner-service/*
 
 %changelog
-* Sun Feb 10 2019 Paul Cuzner <pcuzner@redhat.com> 0.9-3
-- minor updates to improve packaging workflow
-* Mon Dec 17 2018 Paul Cuzner <pcuzner@redhat.com> 0.9
-- Repackaged for 0.9, including more specific package dependencies
-* Mon Sep 24 2018 Paul Cuzner <pcuzner@redhat.com> 0.8
-- initial rpm packaging
+* Thu Jun 20 2019 Juan Miguel Olmo <jolmomar@redhat.com> 0.9-3
+- Initial rpm packaging to use Ansible Runner Service in containers


### PR DESCRIPTION
I have tested the new rpm produced using the file "ars_source.spec" in a clean centos7.

Note: 
As source i have used a tar.gz file of the ansible-runner-service folder ( only *.yaml, *.py files) and i have included only the folders "runner-service" and "samples"  

**To test, I have done manually the same steps that we have in the current Dockerfile:**

1. Install rpm
#rpm -ivh ansible-runner-service-0.9-3.fc28.noarch.rpm

NOTE: Is important that by default python3 will be the default python interpreter,  because all the python dependencies that we are using in the Dockerfile  are installed for python 3.

2. Following the docker file order i have installed dependencies. _Here is where if we want the container using  rhel8 we will need to put the **right downstream** dependencies._


```
# Install dependencies
   yum -y install epel-release  && \
    yum -y install bash wget unzip \
           pexpect python-daemon  bubblewrap gcc \
           bzip2  openssh openssh-clients python2-psutil\
           python36 python36-devel python36-setuptools\
           nginx supervisor && \
           localedef -c -i en_US -f UTF-8 en_US.UTF-8

  easy_install-3.6 -d /usr/lib/python3.6/site-packages pip && \
  ln -s /usr/lib/python3.6/site-packages/pip3 /usr/local/bin/pip3

  /usr/local/bin/pip3 install ansible crypto docutils psutil paramiko PyYAML \
                 pyOpenSSL flask flask-restful uwsgi netaddr notario && \
    /usr/local/bin/pip3 install --no-cache-dir ansible-runner==1.3.2 && \
    rm -rf /var/cache/yum

# Prepare folders for shared access and ssh
    mkdir -p /etc/ansible-runner-service && \
    mkdir -p /root/.ssh && \
    mkdir -p /usr/share/ansible-runner-service/{artifacts,env,project,inventory,client_cert}
```


3. copy the configuration files in the right places:

```
# Nginx configuration
COPY ./misc/nginx/nginx.conf /etc/nginx/

# Ansible Runner Service nginx virtual server
COPY ./misc/nginx/ars_site_nginx.conf /etc/nginx/conf.d

# Ansible Runner Service uwsgi settings
COPY ./misc/nginx/uwsgi.ini /root/ansible-runner-service

# Supervisor start sequence
COPY ./misc/nginx/supervisord.conf /root/ansible-runner-service

# wsgi module  <------------------  This is new
COPY ./wsgi.py /root/ansible-runner-service

```

4. Generate certificates using the "generate:_certs.sh" script

5. Start the service using supervisor

`# supervisord -c /root/ansible-runner-service/supervisord.conf`


6 check that everything is working:

`# curl -s -i -k  --key client.key --cert client.crt   https://localhost:5001/api/v1/playbooks -X GET`





