### PR TITLE
Use OSError instead of PermissionError

### DIFF
--- a/runner_service/utils.py
+++ b/runner_service/utils.py
@@ -115,7 +115,7 @@ def ssh_create_key(ssh_dir, user=None):
                     format=serialization.PrivateFormat.TraditionalOpenSSL,
                     encryption_algorithm=serialization.NoEncryption()))
 
-    except (PermissionError, IOError) as err:
+    except (OSError, IOError) as err:
         msg = "Unable to write to private key to '{}': {}".format(ssh_dir, err)
         logger.critical(msg)
         raise RunnerServiceError(msg)
@@ -134,7 +134,7 @@ def ssh_create_key(ssh_dir, user=None):
                     encoding=serialization.Encoding.OpenSSH,
                     format=serialization.PublicFormat.OpenSSH))
 
-    except (PermissionError, IOError) as err:
+    except (OSError, IOError) as err:
         msg = "Unable to write public ssh key to {}: {}".format(ssh_dir, err)
         logger.critical(msg)
         raise RunnerServiceError(msg)


### PR DESCRIPTION
Python2 doesn't have PermissionError exception. This PR changes to use
OSError instead of PermissionError so it's Python2 compatible. OSError
is parent of PermissionError so it catches more cases of OS related
error, but that's OK for the use case where it's used.