### PR TITLE
introduce sha256 signature and increase modulus lenght

### DIFF
--- a/misc/nginx/generate_certs.sh
+++ b/misc/nginx/generate_certs.sh
@@ -43,30 +43,30 @@ mkdir -p $BASE_PATH/client
 
 echo "Create the CA Key and Certificate for signing Client Certs"
 openssl genrsa -des3 -out $BASE_PATH/server/ca.key -passout pass:$CERT_PASSWORD 4096
-openssl req -new -x509 -days 365 -key $BASE_PATH/server/ca.key -out $BASE_PATH/server/ca.crt -passin pass:$CERT_PASSWORD -subj "$CERT_IDENTITY"
+openssl req -new -x509 -sha256 -days 365 -key $BASE_PATH/server/ca.key -out $BASE_PATH/server/ca.crt -passin pass:$CERT_PASSWORD -subj "$CERT_IDENTITY"
 
 
 # Server -----------------------------------------------------------------------
 
 echo "Create the Server Key, CSR, and Certificate"
-openssl genrsa -des3 -out $BASE_PATH/server/server.key.org -passout pass:$CERT_PASSWORD 1024
+openssl genrsa -des3 -out $BASE_PATH/server/server.key.org -passout pass:$CERT_PASSWORD 4096
 # Remove password (avoid server claiming for it each time it starts)
 openssl rsa -in $BASE_PATH/server/server.key.org -out $BASE_PATH/server/server.key -passin pass:$CERT_PASSWORD
 # Generate server certificate
-openssl req -new -key $BASE_PATH/server/server.key -out $BASE_PATH/server/server.csr -passin pass:$CERT_PASSWORD -subj "$CERT_IDENTITY"
+openssl req -new -sha256 -key $BASE_PATH/server/server.key -out $BASE_PATH/server/server.csr -passin pass:$CERT_PASSWORD -subj "$CERT_IDENTITY"
 
 echo "Self-sign the certificate with our CA cert"
-openssl x509 -req -days 365 -in $BASE_PATH/server/server.csr -CA $BASE_PATH/server/ca.crt -CAkey $BASE_PATH/server/ca.key -set_serial 01 -out $BASE_PATH/server/server.crt -passin pass:$CERT_PASSWORD
+openssl x509 -req -sha256 -days 365 -in $BASE_PATH/server/server.csr -CA $BASE_PATH/server/ca.crt -CAkey $BASE_PATH/server/ca.key -set_serial 01 -out $BASE_PATH/server/server.crt -passin pass:$CERT_PASSWORD
 
 
 # Client -----------------------------------------------------------------------
 
 echo "Create the Client Key and CSR"
-openssl genrsa -des3 -out $BASE_PATH/client/client.key.org -passout pass:$CERT_PASSWORD 1024
+openssl genrsa -des3 -out $BASE_PATH/client/client.key.org -passout pass:$CERT_PASSWORD 4096
 # Remove password (avoid https client claiming for it in each request)
 openssl rsa -in $BASE_PATH/client/client.key.org -out $BASE_PATH/client/client.key -passin pass:$CERT_PASSWORD
 # Generate client certificate
-openssl req -new -key $BASE_PATH/client/client.key -out $BASE_PATH/client/client.csr -passin pass:$CERT_PASSWORD -subj "$CERT_IDENTITY_CLIENT"
+openssl req -new -sha256 -key $BASE_PATH/client/client.key -out $BASE_PATH/client/client.csr -passin pass:$CERT_PASSWORD -subj "$CERT_IDENTITY_CLIENT"
 
 echo "Sign the client certificate with our CA cert"
-openssl x509 -req -days 365 -in $BASE_PATH/client/client.csr -CA $BASE_PATH/server/ca.crt -CAkey $BASE_PATH/server/ca.key -CAcreateserial -out $BASE_PATH/client/client.crt -passin pass:$CERT_PASSWORD
+openssl x509 -req -sha256 -days 365 -in $BASE_PATH/client/client.csr -CA $BASE_PATH/server/ca.crt -CAkey $BASE_PATH/server/ca.key -CAcreateserial -out $BASE_PATH/client/client.crt -passin pass:$CERT_PASSWORD

--- a/misc/nginx/generate_client_cert.sh
+++ b/misc/nginx/generate_client_cert.sh
@@ -35,11 +35,11 @@ mkdir -p $BASE_PATH/client
 # Client -----------------------------------------------------------------------
 
 echo "Create the Client Key and CSR"
-openssl genrsa -des3 -out $BASE_PATH/client/client.key.org -passout pass:$CERT_PASSWORD 2048
+openssl genrsa -des3 -out $BASE_PATH/client/client.key.org -passout pass:$CERT_PASSWORD 4096
 # Remove password (avoid https client claiming for it in each request)
 openssl rsa -in $BASE_PATH/client/client.key.org -out $BASE_PATH/client/client.key -passin pass:$CERT_PASSWORD
 # Generate client certificate
-openssl req -new -key $BASE_PATH/client/client.key -out $BASE_PATH/client/client.csr -passin pass:$CERT_PASSWORD -subj "$CERT_IDENTITY_CLIENT"
+openssl req -new -sha256 -key $BASE_PATH/client/client.key -out $BASE_PATH/client/client.csr -passin pass:$CERT_PASSWORD -subj "$CERT_IDENTITY_CLIENT"
 
 echo "Sign the client certificate with our CA cert"
-openssl x509 -req -days 365 -in $BASE_PATH/client/client.csr -CA $BASE_PATH/server/ca.crt -CAkey $BASE_PATH/server/ca.key -CAcreateserial -out $BASE_PATH/client/client.crt -passin pass:$CERT_PASSWORD
+openssl x509 -req -sha256 -days 365 -in $BASE_PATH/client/client.csr -CA $BASE_PATH/server/ca.crt -CAkey $BASE_PATH/server/ca.key -CAcreateserial -out $BASE_PATH/client/client.crt -passin pass:$CERT_PASSWORD


### PR DESCRIPTION
Introduce new and stronger signature using sha256 and increasing modulus length to 4K.

Mandatory for downstream container (rhel8) and good for every container build with any other base image.