### PR TITLE
Several tags

### DIFF
--- a/runner_service/controllers/playbooks.py
+++ b/runner_service/controllers/playbooks.py
@@ -293,7 +293,7 @@ class StartTaggedPlaybook(BaseResource):
             _e.status, _e.msg = "INVALID", "tag based run requested, but tags are missing?"
             return _e.__dict__, self.state_to_http[_e.status]
 
-        pattern = re.compile(r'[a-z0-9]+$')
+        pattern = re.compile(r'[a-zA-Z0-9\,]+$')
         if not pattern.match(tags) or tags[-1] == ',':
             _e.status, _e.msg = "INVALID", "Invalid tag syntax"
             return _e.__dict__, self.state_to_http[_e.status]

--- a/runner_service/controllers/playbooks.py
+++ b/runner_service/controllers/playbooks.py
@@ -269,6 +269,7 @@ class StartTaggedPlaybook(BaseResource):
         Start a given playbook using tags to control execution.
         The call is expected to be in json format and may contain json 'payload' to define the variables
         required by the playbook
+        The {tags} component is a list of one or more tags separated by comma
         Example.
 
         ```


### PR DESCRIPTION
Using more that one tag executing a playbook produce the error:
"Invalid tag syntax"

Changes in string used to parse the tags allow now to use several tags separated by ","(comma) and using capital letters if desired:

Example:
**Using this test playbook:**

test_tags.yml
```
---
- hosts: localhost
  become: true
  tasks:
  - debug:
      msg: "hi one"
    tags: one
  - debug:
      msg: "hi two"
    tags: two
  - debug:
      msg: "hi three"
    tags: three
```


And executing:

**Using three tags:**

```
$ curl -k -i --key ./client.key --cert ./client.crt -H "Content-Type: application/json"  --data '{}' https://localhost:5001/api/v1/playbooks/test_tags.yml/tags/one,two,three -X POST
HTTP/1.1 202 ACCEPTED
Server: nginx/1.12.2
Date: Tue, 23 Jul 2019 15:21:33 GMT
Content-Type: application/json
Content-Length: 104
Connection: keep-alive

{"status": "STARTED", "msg": "starting", "data": {"play_uuid": "8dc7bf5e-ad5d-11e9-b126-2016b900e38f"}}

```
Produces the following output: ( obtained from the artifacts folder)
```
...
TASK [debug] *******************************************************************
Tuesday 23 July 2019  15:21:40 +0000 (0:00:04.610)       0:00:04.793 ********** 
ok: [localhost] => {
    "msg": "hi one"
}

TASK [debug] *******************************************************************
Tuesday 23 July 2019  15:21:40 +0000 (0:00:00.037)       0:00:04.830 ********** 
ok: [localhost] => {
    "msg": "hi two"
}

TASK [debug] *******************************************************************
Tuesday 23 July 2019  15:21:41 +0000 (0:00:00.036)       0:00:04.866 ********** 
ok: [localhost] => {
    "msg": "hi three"
}

PLAY RECAP *********************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
...
```

**Using two tags:**

```
$ curl -k -i --key ./client.key --cert ./client.crt -H "Content-Type: application/json"  --data '{}' https://localhost:5001/api/v1/playbooks/test_tags.yml/tags/one,three -X POST
HTTP/1.1 202 ACCEPTED
Server: nginx/1.12.2
Date: Tue, 23 Jul 2019 15:24:09 GMT
Content-Type: application/json
Content-Length: 104
Connection: keep-alive

{"status": "STARTED", "msg": "starting", "data": {"play_uuid": "eb149f9c-ad5d-11e9-b126-2016b900e38f"}}

```
Produces the following output: ( obtained from the artifacts folder)

```
TASK [debug] *******************************************************************
Tuesday 23 July 2019  15:24:13 +0000 (0:00:00.960)       0:00:01.136 ********** 
ok: [localhost] => {
    "msg": "hi one"
}

TASK [debug] *******************************************************************
Tuesday 23 July 2019  15:24:13 +0000 (0:00:00.032)       0:00:01.169 ********** 
ok: [localhost] => {
    "msg": "hi three"
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```

**Using only one tag:**

```
$ curl -k -i --key ./client.key --cert ./client.crt -H "Content-Type: application/json"  --data '{}' https://localhost:5001/api/v1/playbooks/test_tags.yml/tags/two -X POST
HTTP/1.1 202 ACCEPTED
Server: nginx/1.12.2
Date: Tue, 23 Jul 2019 15:25:44 GMT
Content-Type: application/json
Content-Length: 104
Connection: keep-alive

{"status": "STARTED", "msg": "starting", "data": {"play_uuid": "238d45f4-ad5e-11e9-b126-2016b900e38f"}}
```

Produces the following output: ( obtained from the artifacts folder)

```
TASK [debug] *******************************************************************
Tuesday 23 July 2019  15:25:48 +0000 (0:00:00.946)       0:00:01.125 ********** 
ok: [localhost] => {
    "msg": "hi two"
}

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```