### PR TITLE
Remove paramiko (tested)

### DIFF
--- a/TODO
+++ b/TODO
@@ -13,8 +13,8 @@ Security on the Api
 - with expiring tokens the "exploit window" is reduced
 - use https as the api endpoint
 
-What to do about Hosts? (integrate with paramiko)
-- post - hostname and root password in the payload, use paramiko to establish
+What to do about Hosts?
+- post - hostname and root password in the payload, extend utils.py/SSHClient class?
                    passwordless ssh - return 200 if login successful
 - put request update a host to belong to a given groups
 

--- a/misc/docker/Dockerfile
+++ b/misc/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN yum -y install epel-release  && \
            localedef -c -i en_US -f UTF-8 en_US.UTF-8
 RUN easy_install-3.6 -d /usr/lib/python3.6/site-packages pip && \
     ln -s /usr/lib/python3.6/site-packages/pip3 /usr/local/bin/pip3
-RUN /usr/local/bin/pip3 install crypto docutils psutil paramiko PyYAML \
+RUN /usr/local/bin/pip3 install cryptography docutils psutil PyYAML \
                  pyOpenSSL flask flask-restful && \
     /usr/local/bin/pip3 install --no-cache-dir ansible-runner==1.3.2 && \
     rm -rf /var/cache/yum

--- a/misc/nginx/Dockerfile
+++ b/misc/nginx/Dockerfile
@@ -11,7 +11,7 @@ RUN yum -y install epel-release  && \
 RUN easy_install-3.6 -d /usr/lib/python3.6/site-packages pip && \
     ln -s /usr/lib/python3.6/site-packages/pip3 /usr/local/bin/pip3
 
-RUN /usr/local/bin/pip3 install ansible crypto docutils psutil paramiko PyYAML \
+RUN /usr/local/bin/pip3 install ansible cryptography docutils psutil PyYAML \
                  pyOpenSSL flask flask-restful uwsgi netaddr notario && \
     /usr/local/bin/pip3 install --no-cache-dir ansible-runner==1.3.2 && \
     rm -rf /var/cache/yum

--- a/misc/nginx/Dockerfile.python27
+++ b/misc/nginx/Dockerfile.python27
@@ -5,7 +5,7 @@ RUN yum -y install bash wget unzip gcc \
            python-devel python-setuptools \
            nginx supervisor
 
-RUN pip install paramiko PyYAML netaddr notario\
+RUN pip install cryptography PyYAML netaddr notario\
     pyOpenSSL flask flask-restful uwsgi && \
     rm -rf /var/cache/yum
 

--- a/misc/packaging/ansible-runner-service-nginx.spec
+++ b/misc/packaging/ansible-runner-service-nginx.spec
@@ -21,8 +21,7 @@ Requires: ansible >= 2.6
 Requires: ansible-runner >= 1.3.2
 Requires: python-flask >= 1.0.2
 Requires: python2-flask-restful >= 0.3.5
-Requires: python2-crypto
-Requires: python-paramiko
+Requires: python2-cryptography
 Requires: openssl
 Requires: pyOpenSSL
 Requires: PyYAML

--- a/misc/packaging/ansible-runner-service.spec
+++ b/misc/packaging/ansible-runner-service.spec
@@ -20,8 +20,7 @@ Requires: ansible >= 2.6
 Requires: ansible-runner >= 1.1
 Requires: python-flask >= 1.0.2
 Requires: python2-flask-restful >= 0.3.5
-Requires: python2-crypto
-Requires: python-paramiko
+Requires: python2-cryptography
 Requires: openssl
 Requires: pyOpenSSL
 Requires: PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ansible_runner==1.3.0
-crypto
-paramiko
+cryptography
 PyYAML
 pyOpenSSL
 flask

--- a/runner_service/utils.py
+++ b/runner_service/utils.py
@@ -215,7 +215,7 @@ class SSHClient(object):
         except Exception as e:
             raise SSHUnknownError(e)
         else:
-            if 'permission denied' in stderr.lower():
+            if 'permission denied' in stderr.decode().lower():
                 raise SSHAuthFailure(stderr)
         finally:
             timer.cancel()

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,7 @@ envlist = py27,py36,setup,linter
 [testenv]
 deps =
     ansible_runner
-    crypto
-    paramiko
+    cryptography
     PyYAML
     pyOpenSSL
     flask


### PR DESCRIPTION
The "remove-paramiko" branch was 6 commits behind master ... in order to build the container with the latest changes i was forced to rebase with master. This is why we have 6 commits after @pcuzner modifications.

During testing it was needed to fix a problem arose when comparing "stderr" with a string (when an error is produced because there is no ssh access to the remote host) . See commit 9534ca1 - stderr returned as bytes.

**Manual Testing:**

**1. Check that ARS ssh keys are created**

**a. Doble check that we haven't got the service ssh keys in the env folder**

```
$ pwd
/usr/share/ansible-runner-service/env

$ ls -la
total 16
drwxr-xr-x. 2 root root 4096 Jul 24 12:01 .
drwxr-xr-x. 9 root root 4096 May 29 17:21 ..
-rw-r--r--. 1 root root   10 Jul 23 17:25 cmdline
-r--------. 1 root root   33 Jul 23 17:25 settings
```

**b. Start the container and check that ssh keys are generated**

After start the container, in the ansible-runner-service.log we found:

```
2019-07-24 10:03:19,328 - root - INFO - Loaded logging configuration from /etc/ansible-runner-service/logging.yaml
2019-07-24 10:03:19,329 - root - INFO - Run mode is: prod
2019-07-24 10:03:19,329 - root - DEBUG - No SSH keys present in /usr/share/ansible-runner-service/env
2019-07-24 10:03:19,329 - root - INFO - Creating SSH keys
2019-07-24 10:03:19,476 - runner_service.utils - INFO - Created SSH private key @ '/usr/share/ansible-runner-service/env/ssh_key'
2019-07-24 10:03:19,476 - runner_service.utils - INFO - Created SSH public key @ '/usr/share/ansible-runner-service/env/ssh_key.pub'
```

In the "env" folder we have:

```
$ ls -la
total 24
drwxr-xr-x. 2 root root 4096 Jul 24 12:03 .
drwxr-xr-x. 9 root root 4096 May 29 17:21 ..
-rw-r--r--. 1 root root   10 Jul 23 17:25 cmdline
-r--------. 1 root root   33 Jul 23 17:25 settings
-rw-------. 1 root root 3243 Jul 24 12:03 ssh_key     <--------------- NEW PRIVATE SSH KEY
-rw-------. 1 root root  724 Jul 24 12:03 ssh_key.pub <--------------- NEW PUBLIC SSH KEY
```

**Check private key:**

```
$ sudo openssl rsa -in ssh_key -text | grep "Private"
Private-Key: (4096 bit)
writing RSA key

$ sudo openssl rsa -in ssh_key -check
RSA key ok
writing RSA key
-----BEGIN RSA PRIVATE KEY-----
MIIJKAIBAAKCAgEAqTcdl+DTBTqdbjPWENcGbmsLBKyY/VDIE4AFp82PJ3LPSGhl
...
```

**Check Public key:**
```
$ sudo ssh-keygen -l -f ssh_key.pub -v
4096 SHA256:BiYYjcKOPMx4FuuDhK0J4FlQdKFR5fvdgRs3jFfyOi4 no comment (RSA)
+---[RSA 4096]----+
|..=*.+o.         |
|o.o+= .          |
|@o++. o.     . . |
|=X=  o ..   + +  |
|oB.    .S  + * . |
|+ o    .. . * +  |
|   .     . o +   |
|           E. .  |
|            ..   |
+----[SHA256]-----+

```



**2. Check that we use this keys to access external hosts**
**2.1 Try to add one external hosts (it shouldn't work)**

```
$ curl -k -i --key ./client.key --cert ./client.crt https://localhost:5001/api/v1/hosts/testsrv/groups/osds -X POST
HTTP/1.1 401 UNAUTHORIZED
Server: nginx/1.12.2
Date: Wed, 24 Jul 2019 16:08:13 GMT
Content-Type: application/json
Content-Length: 843
Connection: keep-alive

{"status": "NOAUTH", "msg": "SSH auth error - passwordless ssh not configured for 'testsrv'", "data": {"pub_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpNx2X4NMFOp1uM9YQ1wZuawsErJj9UMgTgAWnzY8ncs9IaGVRuFxw+emX7jV6Jp03ZuAa/NulqYl5t+OJjWKMQvIjLY0tl1L/9R7RmzGM6OpV20aWiYLVIuISxEAKne6BUDnyEY8ZEWsuDuAXOi13zKDi9OxwokMUXSKvgjgozsk0HMfaHVlXWxbju8dCJVzXgv6ECjEia0Eapu9un/LB5X29qJIAJO6/fjYHQ1i/F75/qLC9Pd/MpejNDoOE27gifMKz6bkBOZGcfH2eh6R6biV4wqupczNWnCM4840jkWVVY9Ip5Kh/9lM/dTWSo0ekBwzs2ygROlCKF/etQqZ7KYn2H+RY/x2JADTDzkgrt39gebgfz/lNxAJo2RtTh3aURe/QXTHaOgsFFaQyKnYTZsVwwonJlHVjhh7ps97mdbIAIfHTDSASS8JOuRWNT6mDja2htnL6l4Wc3neA0udhB6viOULAlfEQMFTffbg04VICOJPqMc7VOSw5z3fXnpY/t+EkaGZM9uYo8oD5m4gMkrDhX1LRbEKKGfXHLS33DFh0R0kqCoYn5wmcdMX/9o7VquYfLpKJOLMo5DbSL1OqDUtuM3qWxVtkKKUQQ++DgxFYNrgYv/TQBduHSzVv9qKJur5W+gfPRVmBEMF12GAI5WT3drJHa64QYm+K9oQE8w=="}}
```


NOTE: The pub_key match with the generated public key

**2.2. Copy the service ssh key to the external host**

```
$ sudo ssh-copy-id -i ssh_key.pub root@testsrv
/usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "ssh_key.pub"
The authenticity of host 'testsrv (192.168.111.1)' can't be established.
ECDSA key fingerprint is SHA256:rj45ruhvQrOJWEDmUP2F1uKDjXHdmhbaZ0VBSnbuEuI.
Are you sure you want to continue connecting (yes/no)? yes
/usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
/usr/bin/ssh-copy-id: INFO: 1 key(s) remain to be installed -- if you are prompted now it is to install the new keys
root@testsrv's password: 

Number of key(s) added: 1

Now try logging into the machine, with:   "ssh 'root@testsrv'"
and check to make sure that only the key(s) you wanted were added.
```


**2.3. Try to add again the new host (now it should work)**

```
$ curl -k -i --key ./client.key --cert ./client.crt https://localhost:5001/api/v1/hosts/testsrv/groups/osds -X POST
HTTP/1.1 200 OK
Server: nginx/1.12.2
Date: Wed, 24 Jul 2019 16:18:38 GMT
Content-Type: application/json
Content-Length: 74
Connection: keep-alive

{"status": "OK", "msg": "testsrv added", "data": {"hostname": "testsrv"}}

```
Check the new node is in the group osds:

```
$ curl -k -i --key ./client.key --cert ./client.crt https://localhost:5001/api/v1/groups/osds -X GET
HTTP/1.1 200 OK
Server: nginx/1.12.2
Date: Wed, 24 Jul 2019 16:20:40 GMT
Content-Type: application/json
Content-Length: 78
Connection: keep-alive

{"status": "OK", "msg": "", "data": {"members": ["osd0", "osd1", "testsrv"]}}

```
