### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ansible-runner-service    ![Build status](https://travis-ci.com/pcuzner/ansible-runner-service.svg?branch=master)[![codecov](https://codecov.io/gh/pcuzner/ansible-runner-service/branch/master/graph/badge.svg)](https://codecov.io/gh/pcuzner/ansible-runner-service)
+# ansible-runner-service  
 This project wraps the ansible_runner interface inside a REST API enabling ansible playbooks to be executed and queried from other platforms.
 
 The incentive for this is two-fold;


### PR DESCRIPTION
Removing the build and codecov icons that were
pointing back to the original projects location.

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>