### PR TITLE
Ignore charset when checking content type

### DIFF
--- a/runner_service/controllers/playbooks.py
+++ b/runner_service/controllers/playbooks.py
@@ -138,7 +138,7 @@ def _run_playbook(playbook_name, tags=None):
 
     r = APIResponse()
 
-    if request.content_type != 'application/json':
+    if not request.content_type.startswith('application/json'):
         logger.warning("Invalid request type. Playbook POST requests must be "
                        "in application/json format")
         r.status, r.msg = "UNSUPPORTED", \


### PR DESCRIPTION
Client can sent the content-type in following format:
`
 Content-type: application/json; charset=utf-8
`
With current code, it failed, but it's legit content-type and should
pass.

This PR changes the code so it ignore the charset when checking the
content-type.