### PR TITLE
Add support override inventory hosts by parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The core of this project is ansible_runner, so first of all, a quick call out to
   - supports Ansible environments that use private libraries (ie. the library directory is stored within the project folder)
   - playbooks can be run with tags to change execution behavior
   - playbooks can use limit to restrict actions to a specific host
+  - playbooks can use `hosts` parameter to override inventory hosts
   - running playbooks may be cancelled
   - supports execution of concurrent playbooks
 

--- a/runner_service/controllers/playbooks.py
+++ b/runner_service/controllers/playbooks.py
@@ -134,7 +134,7 @@ def _run_playbook(playbook_name, tags=None):
     # TODO Move this function to the service package (services.playbook)
 
     # TODO We should use a list like this to restrict the query we support
-    valid_filter = ['limit']
+    valid_filter = ['limit', 'hosts']
 
     r = APIResponse()
 
@@ -237,6 +237,29 @@ class StartPlaybook(BaseResource):
 
         ```
         $ curl -k -i --key ./client.key --cert ./client.crt -H "Content-Type: application/json" --data '{"time_delay":20}' https://192.168.121.1:5001/api/v1/playbooks/test.yml?limit=host0,host1 -X POST
+        HTTP/1.1 202 ACCEPTED
+        Server: nginx/1.12.2
+        Date: Wed, 12 Jun 2019 09:59:47 GMT
+        Content-Type: application/json
+        Content-Length: 104
+        Connection: keep-alive
+
+        {
+            "status": "STARTED",
+            "msg": "starting",
+            "data": {"play_uuid": "cfbdd41e-8cf8-11e9-9154-2016b900e38f"
+            }
+        }
+
+        ```
+
+        Example 3:
+
+        Specify the hosts to be used to execute the playbook on,
+        override the hosts specified in the inventory. 
+
+        ```
+        $ curl -k -i --key ./client.key --cert ./client.crt -H "Content-Type: application/json" --data '{"time_delay":20}' 'https://192.168.121.1:5001/api/v1/playbooks/test.yml?hosts=host0.example.com,host1.example.com' -X POST
         HTTP/1.1 202 ACCEPTED
         Server: nginx/1.12.2
         Date: Wed, 12 Jun 2019 09:59:47 GMT

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -243,6 +243,10 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
     if tags:
         cmdline.append("--tags {}".format(tags))
 
+    hosts = filter.get('hosts', None)
+    if hosts:
+        cmdline.append("--hosts {}".format(tags))
+
     if configuration.settings.target_user != getpass.getuser():
         logger.debug("Run the playbook with a user override of "
                      "{}".format(configuration.settings.target_user))


### PR DESCRIPTION
This PR add support to override invetory hosts by `hosts` HTTP POST parameter