### PR TITLE
Set runner_cache as defaultdict of dict

### DIFF
--- a/runner_service/cache.py
+++ b/runner_service/cache.py
@@ -1,4 +1,4 @@
-
+from collections import defaultdict
 
 # define dict based variables to act as caches across other modules
 
@@ -24,6 +24,6 @@ class RunnerStats(object):
 
 event_cache = {}
 
-runner_cache = {}
+runner_cache = defaultdict(dict)
 
 runner_stats = RunnerStats()


### PR DESCRIPTION
runner_cache should be of type defaultdict(dict), because it may happen
that cb_event_handler is called before runner_cache is initialized with
play_uuid.

Fixes: https://github.com/ansible/ansible-runner-service/issues/35