### PR TITLE
Add option to set explicit extravars

### DIFF
--- a/runner_service/controllers/playbooks.py
+++ b/runner_service/controllers/playbooks.py
@@ -134,7 +134,7 @@ def _run_playbook(playbook_name, tags=None):
     # TODO Move this function to the service package (services.playbook)
 
     # TODO We should use a list like this to restrict the query we support
-    valid_filter = ['limit', 'check']
+    valid_filter = ['limit', 'check', 'explicitvars']
 
     r = APIResponse()
 

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -240,6 +240,21 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
     cleanup_dir(os.path.join(configuration.settings.playbooks_root_dir,
                              "env"))
 
+    # If explicit_extravars is set, create empty extrvars file, which will
+    # cause, that extravars file won't be loaded with our extravars, but those
+    # extravars will be passed as command line argument, which is usefull to
+    # not hit race when two proccess are using same extravars file.
+    explicitvars = filter.get('explicitvars', True)
+    if explicitvars:
+        with open(
+            os.path.join(
+                configuration.settings.playbooks_root_dir,
+                'env',
+                'extravars'
+            ), 'w'
+        ) as f:
+            f.write('{}')
+
     cmdline = []
     if filter.get('check', 'false').lower() == 'true':
         cmdline.append('--check')


### PR DESCRIPTION
This PR add option to startplaybook endpoint which explicitly create
empty extravars file, which will enforce the ansible-playbook command to
use extravars as command line parameters, and not to be used from
extravars file.

If two parallel proccess are executed with different extravars specified
and single extravars file is used, it may happen that both proccess uses
same file, with same extravars, which is wrong.

Fixes: https://github.com/ansible/ansible-runner-service/issues/47

For time being I've solved as follows, even that I think it's not right solution.

IMHO, service should pass the runner custom `private_dir` for each execution, and always pass inventory, project_dir, cmdline, etc. So it's not shared. Something like this:

```
diff --git a/runner_service/services/playbook.py b/runner_service/services/playbook.py
index 2bed5bc..62199b2 100644
--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -215,7 +215,9 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
     # this should just be run_async, using 'run' hangs the root logger output
     # even when backgrounded
     parms = {
-        "private_data_dir": configuration.settings.playbooks_root_dir,
+        "project_dir": os.path.join(configuration.settings.playbooks_root_dir, 'project'),
+        "inventory": filter.get('limit'),
         "settings": settings,
         "finished_callback": cb_playbook_finished,
         "event_handler": cb_event_handler,
@@ -236,6 +238,7 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
     if limit_hosts:
         parms['limit'] = limit_hosts

+
     logger.debug("Clearing up old env directory")
     cleanup_dir(os.path.join(configuration.settings.playbooks_root_dir,
                              "env"))
@@ -258,6 +261,7 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
         cmdline.append("--private-key {}".format(configuration.settings.ssh_private_key))

     if cmdline:
+        parms['cmdline'] = ' '.join(cmdline)
-        commit_cmdline(cmdline)

     _thread, _runner = run_async(**parms)
```