### PR TITLE
Force private_data_dir to create tmp folder to allow parallel executions

### DIFF
--- a/packaging/gunicorn/ansible-runner-service.service
+++ b/packaging/gunicorn/ansible-runner-service.service
@@ -3,7 +3,7 @@ Description=Ansible Runner Service
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/gunicorn -b localhost:5001 -w 2 runner_service.wsgi:application
+ExecStart=/usr/bin/gunicorn -b localhost:5001 -w 1 runner_service.wsgi:application
 Restart=always
 
 [Install]

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -215,7 +215,8 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
     # this should just be run_async, using 'run' hangs the root logger output
     # even when backgrounded
     parms = {
-        "private_data_dir": configuration.settings.playbooks_root_dir,
+        "project_dir": os.path.join(configuration.settings.playbooks_root_dir, 'project'),
+        "inventory": filter.get('limit'),
         "settings": settings,
         "finished_callback": cb_playbook_finished,
         "event_handler": cb_event_handler,
@@ -258,7 +259,7 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
         cmdline.append("--private-key {}".format(configuration.settings.ssh_private_key))
 
     if cmdline:
-        commit_cmdline(cmdline)
+        parms['cmdline'] = ' '.join(cmdline)
 
     _thread, _runner = run_async(**parms)
 


### PR DESCRIPTION
This was suggested by Ondra in https://github.com/ansible/ansible-runner-service/pull/48.

This PR allows parallel executions of playbooks. It forces ansible-runner to create private_data_dir in /tmp so the extra vars are not overwritten.

The update in `ansible-runner-service.service` was added, because the service had 2 processes, and the cache was not shared between them.

WDYT @jmolmo @pcuzner?

cc @mwperina