### PR TITLE
Allow parallel execution: put execution to artifacts

### DIFF
--- a/packaging/gunicorn/ansible-runner-service.service
+++ b/packaging/gunicorn/ansible-runner-service.service
@@ -3,7 +3,7 @@ Description=Ansible Runner Service
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/gunicorn -b localhost:5001 -w 2 runner_service.wsgi:application
+ExecStart=/usr/bin/gunicorn -b localhost:5001 -w 1 runner_service.wsgi:application
 Restart=always
 
 [Install]

--- a/packaging/gunicorn/ansible-runner-service.service
+++ b/packaging/gunicorn/ansible-runner-service.service
@@ -3,7 +3,7 @@ Description=Ansible Runner Service
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/gunicorn -b localhost:5001 -w 1 runner_service.wsgi:application
+ExecStart=/usr/bin/gunicorn -b localhost:5001 -w 2 runner_service.wsgi:application
 Restart=always
 
 [Install]

--- a/runner_service/configuration.py
+++ b/runner_service/configuration.py
@@ -28,10 +28,10 @@ class Config(object):
             "debug": False
         },
         "dev": {
-            "logging_conf": "./logging.yaml",
-            "log_path": "./",
-            "config_file": "./config.yaml",
-            "playbooks_root_dir": "./samples",
+            "logging_conf": os.path.abspath("./logging.yaml"),
+            "log_path": os.path.abspath("./"),
+            "config_file": os.path.abspath("./config.yaml"),
+            "playbooks_root_dir": os.path.abspath("./samples"),
             "debug": True
         }
     }
@@ -50,9 +50,7 @@ class Config(object):
         self.debug = Config.MODES[mode].get("debug", True)
 
         # Path to custom ssh key, by default project/env/ssh_key is used
-        self.ssh_private_key = os.path.abspath(
-            os.path.join(self.playbooks_root_dir, "env/ssh_key")
-        )
+        self.ssh_private_key = os.path.join(self.playbooks_root_dir, "env/ssh_key")
 
         # expiration period in years for the self-signed cert that we generate
         self.cert_expiration = 3

--- a/runner_service/configuration.py
+++ b/runner_service/configuration.py
@@ -50,7 +50,10 @@ class Config(object):
         self.debug = Config.MODES[mode].get("debug", True)
 
         # Path to custom ssh key, by default project/env/ssh_key is used
-        self.ssh_private_key = os.path.join(self.playbooks_root_dir, "env/ssh_key")
+        self.ssh_private_key = os.path.join(
+            self.playbooks_root_dir,
+            "env/ssh_key"
+        )
 
         # expiration period in years for the self-signed cert that we generate
         self.cert_expiration = 3

--- a/runner_service/configuration.py
+++ b/runner_service/configuration.py
@@ -77,6 +77,8 @@ class Config(object):
         # flask config setting to hide the "production use" warning
         self.ENV = ''
 
+        self.max_artifacts = None
+
         self._apply_overrides()
 
     def _apply_local(self):

--- a/runner_service/configuration.py
+++ b/runner_service/configuration.py
@@ -50,9 +50,8 @@ class Config(object):
         self.debug = Config.MODES[mode].get("debug", True)
 
         # Path to custom ssh key, by default project/env/ssh_key is used
-        self.ssh_private_key = os.path.join(
-            self.playbooks_root_dir,
-            "env/ssh_key"
+        self.ssh_private_key = os.path.abspath(
+            os.path.join(self.playbooks_root_dir, "env/ssh_key")
         )
 
         # expiration period in years for the self-signed cert that we generate

--- a/runner_service/configuration.py
+++ b/runner_service/configuration.py
@@ -77,8 +77,6 @@ class Config(object):
         # flask config setting to hide the "production use" warning
         self.ENV = ''
 
-        self.max_artifacts = None
-
         self._apply_overrides()
 
     def _apply_local(self):

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -195,9 +195,12 @@ def cb_event_handler(event_data):
 
 
 def remove_oldest_artifacts(artifacts_dir):
-    file = min(os.listdir(artifacts_dir), key=lambda f: os.path.getctime("{}/{}".format(artifacts_dir, f)))
-    if file:
-        shutil.rmtree(os.path.join(artifacts_dir, file))
+    # Get list of artifacts sorted from oldest to newest.
+    files = sorted(os.listdir(artifacts_dir), key=lambda f: os.path.getctime("{}/{}".format(artifacts_dir, f)))
+
+    # If user has more artifacts than specified it will remove until it has proper number of artifacts.
+    for i in range(len(files) - configuration.settings.max_artifacts + 1):
+        shutil.rmtree(os.path.join(artifacts_dir, files[i]))
 
 
 def start_playbook(playbook_name, vars=None, filter=None, tags=None):

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -1,3 +1,4 @@
+
 import os
 import glob
 import uuid

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -167,7 +167,7 @@ def cb_event_handler(event_data):
         # role is not a fixed attribute
         role_value = ''
         if 'role' in event_data:
-            role_value = runner_cache[ident]['role'] = event_data['event_data'].get('role', '')  # noqa
+            role_value = runner_cache[ident]['role'] = event_data['event_data'].get('role', '') # noqa
         runner_cache[ident]['role'] = role_value
 
         if event_type.startswith("runner_on_"):
@@ -183,11 +183,11 @@ def cb_event_handler(event_data):
                 else:
                     # we have a valid failure to report
                     event_metadata = event_data['event_data']
-                    runner_cache[ident]['failures'][event_metadata.get('host')] = event_data  # noqa
+                    runner_cache[ident]['failures'][event_metadata.get('host')] = event_data # noqa
 
     # populate the event cache
     if 'runner_ident' in event_data and \
-            'uuid' in event_data and ident in event_cache:
+        'uuid' in event_data and ident in event_cache:
         event_cache[ident].update({event_data['uuid']: event_data})
 
     # regardless return true to ensure the data is written to artifacts dir

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -11,7 +11,7 @@ from ansible_runner import run_async
 from ansible_runner.exceptions import AnsibleRunnerException
 from runner_service import configuration
 from runner_service.cache import runner_cache, runner_stats
-from .utils import cleanup_dir, APIResponse
+from .utils import APIResponse
 from ..utils import fread
 
 from ..cache import event_cache

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -1,11 +1,9 @@
-
 import os
 import glob
 import uuid
 import time
 import datetime
 import getpass
-import shutil
 
 from ansible_runner import run_async
 from ansible_runner.exceptions import AnsibleRunnerException

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -217,7 +217,7 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
     # even when backgrounded
 
     artifacts_dir = os.path.join(configuration.settings.playbooks_root_dir, "artifacts")
-    if configuration.settings.max_artifacts is not None and len(os.listdir(artifacts_dir)) >= configuration.settings.max_artifacts:
+    if configuration.settings.max_artifacts is not None:
         remove_oldest_artifacts(artifacts_dir)
 
     private_data_dir = os.path.join(artifacts_dir, play_uuid)

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -231,7 +231,8 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
         "event_handler": cb_event_handler,
         "quiet": False,
         "ident": play_uuid,
-        "playbook": playbook_name
+        "playbook": playbook_name,
+        "inventory": filter.get('limit'),
     }
 
     if os.path.exists(local_modules):

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -11,6 +11,7 @@ from ansible_runner import run_async
 from ansible_runner.exceptions import AnsibleRunnerException
 from runner_service import configuration
 from runner_service.cache import runner_cache, runner_stats
+from runner_service.utils import rm_r
 from .utils import APIResponse
 from ..utils import fread
 
@@ -200,7 +201,7 @@ def remove_oldest_artifacts(artifacts_dir):
 
     # If user has more artifacts than specified it will remove until it has proper number of artifacts.
     for i in range(len(files) - configuration.settings.max_artifacts + 1):
-        shutil.rmtree(os.path.join(artifacts_dir, files[i]))
+        rm_r(os.path.join(artifacts_dir, files[i]))
 
 
 def start_playbook(playbook_name, vars=None, filter=None, tags=None):

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -10,7 +10,6 @@ from ansible_runner import run_async
 from ansible_runner.exceptions import AnsibleRunnerException
 from runner_service import configuration
 from runner_service.cache import runner_cache, runner_stats
-from runner_service.utils import rm_r
 from .utils import APIResponse
 from ..utils import fread
 
@@ -194,15 +193,6 @@ def cb_event_handler(event_data):
     return True
 
 
-def remove_oldest_artifacts(artifacts_dir):
-    # Get list of artifacts sorted from oldest to newest.
-    files = sorted(os.listdir(artifacts_dir), key=lambda f: os.path.getctime("{}/{}".format(artifacts_dir, f)))
-
-    # If user has more artifacts than specified it will remove until it has proper number of artifacts.
-    for i in range(len(files) - configuration.settings.max_artifacts + 1):
-        rm_r(os.path.join(artifacts_dir, files[i]))
-
-
 def start_playbook(playbook_name, vars=None, filter=None, tags=None):
     """ Initiate a playbook run """
 
@@ -217,9 +207,6 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
     # even when backgrounded
 
     artifacts_dir = os.path.join(configuration.settings.playbooks_root_dir, "artifacts")
-    if configuration.settings.max_artifacts is not None:
-        remove_oldest_artifacts(artifacts_dir)
-
     private_data_dir = os.path.join(artifacts_dir, play_uuid)
     os.mkdir(private_data_dir)
     parms = {

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -246,13 +246,11 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
                      "{}".format(configuration.settings.target_user))
         cmdline.append("--user {}".format(configuration.settings.target_user))
 
-    if not configuration.settings.ssh_private_key.endswith('env/ssh_key'):
-        logger.debug("Run the playbook with a private key override of "
-                     "{}".format(configuration.settings.ssh_private_key))
-        cmdline.append("--private-key {}".format(configuration.settings.ssh_private_key))
+    logger.debug("Run the playbook with a private key override of "
+                 "{}".format(configuration.settings.ssh_private_key))
+    cmdline.append("--private-key {}".format(configuration.settings.ssh_private_key))
 
-    if cmdline:
-        parms['cmdline'] = ' '.join(cmdline)
+    parms['cmdline'] = ' '.join(cmdline)
 
     _thread, _runner = run_async(**parms)
 

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -206,12 +206,12 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
     # this should just be run_async, using 'run' hangs the root logger output
     # even when backgrounded
 
-    artifacts_dir = os.path.join(configuration.settings.playbooks_root_dir, "artifacts")
+    artifacts_dir = os.path.abspath(os.path.join(configuration.settings.playbooks_root_dir, "artifacts"))
     private_data_dir = os.path.join(artifacts_dir, play_uuid)
     os.mkdir(private_data_dir)
     parms = {
         "private_data_dir": private_data_dir,
-        "project_dir": os.path.join(configuration.settings.playbooks_root_dir, 'project'),
+        "project_dir": os.path.abspath(os.path.join(configuration.settings.playbooks_root_dir, 'project')),
         "artifact_dir": artifacts_dir,
         "settings": settings,
         "finished_callback": cb_playbook_finished,
@@ -219,7 +219,7 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
         "quiet": False,
         "ident": play_uuid,
         "playbook": playbook_name,
-        "inventory": filter.get('limit'),
+        "inventory": os.path.abspath(os.path.join(configuration.settings.playbooks_root_dir, 'inventory')),
     }
 
     if os.path.exists(local_modules):

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -206,20 +206,20 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
     # this should just be run_async, using 'run' hangs the root logger output
     # even when backgrounded
 
-    artifacts_dir = os.path.abspath(os.path.join(configuration.settings.playbooks_root_dir, "artifacts"))
+    artifacts_dir = os.path.join(configuration.settings.playbooks_root_dir, "artifacts")
     private_data_dir = os.path.join(artifacts_dir, play_uuid)
     os.makedirs(private_data_dir)
     parms = {
         "private_data_dir": private_data_dir,
-        "project_dir": os.path.abspath(os.path.join(configuration.settings.playbooks_root_dir, 'project')),
+        "project_dir": os.path.join(configuration.settings.playbooks_root_dir, 'project'),
+        "inventory": os.path.join(configuration.settings.playbooks_root_dir, 'inventory'),
         "artifact_dir": artifacts_dir,
         "settings": settings,
         "finished_callback": cb_playbook_finished,
         "event_handler": cb_event_handler,
         "quiet": False,
         "ident": play_uuid,
-        "playbook": playbook_name,
-        "inventory": os.path.abspath(os.path.join(configuration.settings.playbooks_root_dir, 'inventory')),
+        "playbook": playbook_name
     }
 
     if os.path.exists(local_modules):

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -208,7 +208,7 @@ def start_playbook(playbook_name, vars=None, filter=None, tags=None):
 
     artifacts_dir = os.path.abspath(os.path.join(configuration.settings.playbooks_root_dir, "artifacts"))
     private_data_dir = os.path.join(artifacts_dir, play_uuid)
-    os.mkdir(private_data_dir)
+    os.makedirs(private_data_dir)
     parms = {
         "private_data_dir": private_data_dir,
         "project_dir": os.path.abspath(os.path.join(configuration.settings.playbooks_root_dir, 'project')),

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -167,7 +167,7 @@ def cb_event_handler(event_data):
         # role is not a fixed attribute
         role_value = ''
         if 'role' in event_data:
-            role_value = runner_cache[ident]['role'] = event_data['event_data'].get('role', '') # noqa
+            role_value =  runner_cache[ident]['role'] = event_data['event_data'].get('role', '') # noqa
         runner_cache[ident]['role'] = role_value
 
         if event_type.startswith("runner_on_"):
@@ -187,7 +187,7 @@ def cb_event_handler(event_data):
 
     # populate the event cache
     if 'runner_ident' in event_data and \
-        'uuid' in event_data and ident in event_cache:
+       'uuid' in event_data and ident in event_cache:
         event_cache[ident].update({event_data['uuid']: event_data})
 
     # regardless return true to ensure the data is written to artifacts dir

--- a/runner_service/services/utils.py
+++ b/runner_service/services/utils.py
@@ -19,12 +19,6 @@ def build_pb_path(play_uuid):
                         play_uuid)
 
 
-def cleanup_dir(dir_name, exclude=['ssh_key', 'ssh_key.pub']):
-    for _path_name in glob.glob("{}/*".format(dir_name)):
-        if os.path.basename(_path_name) not in exclude:
-            rm_r(_path_name)
-
-
 def writeYAML(data, path_name):
     try:
         with open(path_name, "w") as yaml_file:

--- a/runner_service/services/utils.py
+++ b/runner_service/services/utils.py
@@ -3,7 +3,6 @@ import glob
 import yaml
 
 import runner_service.configuration as configuration
-from runner_service.utils import rm_r
 
 
 def playbook_exists(playbook_name):


### PR DESCRIPTION
This is another solution for parallel execution others (#50, #48).
Difference compared to #50 that instead of creating `private_data_dir` is created in artifacts instead of tmp folder. 

WDYT @jmolmo @pcuzner?
cc @mwperina @dangel101