### PR TITLE
fix: RuntimeError dictionary changed size during iteration

### DIFF
--- a/runner_service/services/jobs.py
+++ b/runner_service/services/jobs.py
@@ -149,7 +149,7 @@ def get_events(play_uuid, filter):
     #  use cache if possible
     if play_uuid in event_cache:
         local_cache = event_cache.copy()
-        events = local_cache[play_uuid].values()
+        events = list(local_cache[play_uuid].values())
         logger.debug("Job events for play {}: {}".format(play_uuid,
                                                          len(events) - 1))
         logger.debug("Active filter is :{}".format(filter))


### PR DESCRIPTION
Hi,
we were getting this runtime error issue from our CI.
Problem is that I was not able to reproduce it by hand.
```
[2020-04-21 05:54:58,095] ERROR in app: Exception on /api/v1/jobs/1814d9d4-83b5-11ea-92c4-5452c0a8c904/events [GET]
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/lib/python3.6/site-packages/flask_restful/__init__.py", line 458, in wrapper
    resp = resource(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/flask/views.py", line 84, in view
    return self.dispatch_request(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/flask_restful/__init__.py", line 573, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/runner_service/controllers/utils.py", line 29, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/runner_service/controllers/jobs.py", line 83, in get
    response = get_events(play_uuid, filter)
  File "/usr/lib/python3.6/site-packages/runner_service/services/jobs.py", line 157, in get_events
    for event_info in events:
RuntimeError: dictionary changed size during iteration
```