### PR TITLE
fix ansible_runner_service path in wsgi

### DIFF
--- a/packaging/gunicorn/ansible-runner-service.spec
+++ b/packaging/gunicorn/ansible-runner-service.spec
@@ -5,6 +5,7 @@ Version: 1.0.1
 Release: 1%{?dist}
 Summary: RESTful API for ansible/ansible_runner execution
 Source0: https://github.com/ansible/%{name}/archive/%{name}-%{version}.tar.gz
+Patch0:  wsgi.patch
 Group:	 Applications/System
 License: ASL 2.0
 
@@ -63,6 +64,7 @@ Requires: python3-gunicorn
 
 %prep
 %setup -q -n %{name}-%{version}
+%patch0 -p0
 
 %build
 # Disable debuginfo packages

--- a/packaging/gunicorn/wsgi.patch
+++ b/packaging/gunicorn/wsgi.patch
@@ -1,0 +1,12 @@
+diff --git a/wsgi.py b/wsgi.py
+index 6407c08..52eda52 100644
+--- a/wsgi.py
++++ b/wsgi.py
+@@ -1,6 +1,6 @@
+ import runner_service.configuration as configuration
+ from runner_service.app import create_app
+-from ansible_runner_service import setup_common_environment
++from .ansible_runner_service import setup_common_environment
+
+
+ """

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,6 +1,6 @@
 import runner_service.configuration as configuration
 from runner_service.app import create_app
-from .ansible_runner_service import setup_common_environment
+from ansible_runner_service import setup_common_environment
 
 
 """

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,6 +1,6 @@
 import runner_service.configuration as configuration
 from runner_service.app import create_app
-from ansible_runner_service import setup_common_environment
+from .ansible_runner_service import setup_common_environment
 
 
 """


### PR DESCRIPTION
Hello there,
found an issue with path in wsgi.

 @mwperina @dangel101 @jmolmo @pcuzner

Error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
    worker.init_process()
  File "/usr/lib/python3.7/site-packages/gunicorn/workers/base.py", line 129, in init_process
    self.load_wsgi()
  File "/usr/lib/python3.7/site-packages/gunicorn/workers/base.py", line 138, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/usr/lib/python3.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/usr/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load
    return self.load_wsgiapp()
  File "/usr/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 41, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/lib/python3.7/site-packages/gunicorn/util.py", line 350, in import_app
    __import__(module)
  File "/usr/lib/python3.7/site-packages/runner_service/wsgi.py", line 3, in <module>
    from ansible_runner_service import setup_common_environment
ModuleNotFoundError: No module named 'ansible_runner_service'
```