### PR TITLE
Fixing problem installing with pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,15 @@ FROM centos:7
 # Install dependencies
 RUN yum -y install epel-release  && \
     yum -y install bash wget unzip \
-           pexpect python-daemon  bubblewrap gcc \
-           bzip2  openssh openssh-clients python2-psutil\
-           python36 python36-devel python36-setuptools\
-           nginx supervisor && \
-           localedef -c -i en_US -f UTF-8 en_US.UTF-8
-RUN easy_install-3.6 -d /usr/lib/python3.6/site-packages pip && \
-    ln -s /usr/lib/python3.6/site-packages/pip3 /usr/local/bin/pip3
+    pexpect python-daemon  bubblewrap gcc \
+    bzip2  openssh openssh-clients python2-psutil\
+    python36 python36-devel python36-setuptools\
+    nginx supervisor && \
+    localedef -c -i en_US -f UTF-8 en_US.UTF-8
 
-RUN /usr/local/bin/pip3 install ansible cryptography docutils psutil PyYAML \
-                 pyOpenSSL flask flask-restful uwsgi netaddr notario && \
-    /usr/local/bin/pip3 install --no-cache-dir ansible-runner==1.3.2 && \
+RUN /usr/bin/python3 -m pip install ansible cryptography docutils psutil PyYAML \
+    pyOpenSSL flask flask-restful uwsgi netaddr notario && \
+    /usr/bin/python3 -m pip install --no-cache-dir ansible-runner==1.4.6 && \
     rm -rf /var/cache/yum
 
 # Prepare folders for shared access and ssh

--- a/misc/nginx/uwsgi.ini
+++ b/misc/nginx/uwsgi.ini
@@ -2,7 +2,6 @@
 
 # General settings
 logto = /var/log/uwsgi.log
-plugin = python3
 
 # App settings
 chdir = /root/ansible-runner-service


### PR DESCRIPTION
Python 3.6 already includes pip ( what i do not know is why we do not have this problem when we created the Docker file for first time)
Removed the installation of pip using easy-install" because it cause a conflict with the pip installation included with python 3.6. 
Implications:
- Now pip should be used as a python module inside the container
- uwsgi config file does not need to set the plugin to use, it has been set when installing uwsgi with Python3

FIXES: https://github.com/ansible/ansible-runner-service/issues/56