### PR TITLE
api: use default ssh port, if request doesn't give one

### DIFF
--- a/runner_service/controllers/hosts.py
+++ b/runner_service/controllers/hosts.py
@@ -199,7 +199,7 @@ class HostMgmt(BaseResource):
             if all(p in valid_parms for p in args.keys()):
                 if 'others' in args:
                     group_list.extend(args['others'].split(','))
-                ssh_port = self.__to_int(args.get('port', None))
+                ssh_port = self.__to_int(args.get('port', 22))
             else:
                 r = APIResponse()
                 r.status = 'INVALID'


### PR DESCRIPTION
For a new host request, the ssh port can be optionally
provided. If it's not provided we need to default to
prevent a NoneType exception when defining the
ssh_port setting. This patch assigns a default of 22.

Closes: #57

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>