### PR TITLE
Spec files fixes

### DIFF
--- a/misc/packaging/ansible-runner-service.spec
+++ b/misc/packaging/ansible-runner-service.spec
@@ -70,7 +70,7 @@ install -m 0644 ./LICENSE.md %{buildroot}%{_docdir}/ansible-runner-service
 %{_bindir}/ansible_runner_service
 %{python_sitelib}/*
 %{_prefix}/share/ansible-runner-service/*
-%{_sysconfdir}/ansible-runner-service/*
+%config(noreplace) %{_sysconfdir}/ansible-runner-service/*
 %{_unitdir}/ansible-runner-service.service
 %{_docdir}/ansible-runner-service/*
 

--- a/misc/packaging/apache/ansible-runner-service.spec
+++ b/misc/packaging/apache/ansible-runner-service.spec
@@ -82,7 +82,7 @@ install -m 644 ./logging.yaml %{buildroot}%{_sysconfdir}/ansible-runner-service
 %files -n python2-%{srcname}
 %{_bindir}/ansible_runner_service
 %{python2_sitelib}/*
-%{_sysconfdir}/ansible-runner-service/*
+%config(noreplace) %{_sysconfdir}/ansible-runner-service/*
 
 %license LICENSE.md
 

--- a/misc/packaging/nginx/ansible-runner-service-nginx.spec
+++ b/misc/packaging/nginx/ansible-runner-service-nginx.spec
@@ -87,7 +87,7 @@ install -m 0644 ./misc/nginx/uwsgi.ini %{buildroot}%{_sysconfdir}/ansible-runner
 %{_bindir}/ansible_runner_service
 %{python_sitelib}/*
 %{_prefix}/share/ansible-runner-service/*
-%{_sysconfdir}/ansible-runner-service/*
+%config(noreplace) %{_sysconfdir}/ansible-runner-service/*
 %{_sysconfdir}/nginx/conf.d/*
 %{_docdir}/ansible-runner-service/*
 

--- a/packaging/gunicorn/ansible-runner-service.spec
+++ b/packaging/gunicorn/ansible-runner-service.spec
@@ -86,7 +86,7 @@ install -m 644 ./logging.yaml %{buildroot}%{_sysconfdir}/ansible-runner-service
 install -m 644 ./wsgi.py %{buildroot}%{_sysconfdir}/ansible-runner-service
 
 mkdir -p %{buildroot}%{_unitdir}
-cp -r ./packaging/ansible-runner-service.service %{buildroot}%{_unitdir}
+cp -r ./packaging/gunicorn/ansible-runner-service.service %{buildroot}%{_unitdir}
 
 %files -n python2-%{srcname}
 %{_bindir}/ansible_runner_service

--- a/packaging/gunicorn/ansible-runner-service.spec
+++ b/packaging/gunicorn/ansible-runner-service.spec
@@ -91,7 +91,7 @@ cp -r ./packaging/ansible-runner-service.service %{buildroot}%{_unitdir}
 %files -n python2-%{srcname}
 %{_bindir}/ansible_runner_service
 %{python2_sitelib}/*
-%{_sysconfdir}/ansible-runner-service/*
+%config(noreplace) %{_sysconfdir}/ansible-runner-service/*
 %{_unitdir}/ansible-runner-service.service
 
 %license LICENSE.md


### PR DESCRIPTION
Hello there,
found one issue in gunicorn spec and added `%config(noreplace)` to the config so the new rpm will not overwrite the old configs.
@mwperina @dangel101 @jmolmo @pcuzner