### PR TITLE
utils: fix permissions assigned to public key

### DIFF
--- a/runner_service/utils.py
+++ b/runner_service/utils.py
@@ -155,7 +155,7 @@ def ssh_create_key(ssh_dir, user=None):
         raise
     else:
         # python3 syntax
-        os.chmod(pub_file, 0o600)
+        os.chmod(pub_file, 0o644)
         logger.info("Created SSH public key @ '{}'".format(pub_file))
 
 


### PR DESCRIPTION
The autogenerated public key should have 0644
permissions, not 0600.

Closes: #63

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>