### PR TITLE
add ovirt logrotate patch

### DIFF
--- a/misc/packaging/apache/ansible-runner-service.spec
+++ b/misc/packaging/apache/ansible-runner-service.spec
@@ -5,6 +5,7 @@ Version: 1.0.3
 Release: 1%{?dist}
 Summary: RESTful API for ansible/ansible_runner execution
 Source0: https://github.com/ansible/%{name}/archive/%{name}-%{version}.tar.gz
+Patch0:  ovirt_log.patch
 Group:	 Applications/System
 License: ASL 2.0
 
@@ -42,6 +43,7 @@ In addition to the API endpoints, the daemon also provides a /metrics endpoint f
 
 %prep
 %setup -q -n %{name}-%{version}
+%patch0 -p1
 
 %build
 # Disable debuginfo packages

--- a/misc/packaging/apache/ovirt_log.patch
+++ b/misc/packaging/apache/ovirt_log.patch
@@ -17,7 +17,8 @@ index 8357727..16a0c1c 100644
 +        class: logging.handlers.WatchedFileHandler
          level: DEBUG
          formatter: simple
-         filename: ansible-runner-service.log
+-        filename: ansible-runner-service.log
++        filename: /var/log/ovirt-engine/ansible-runner-service.log
 -        maxBytes: 10485760 # 10MB
 -        backupCount: 20
          encoding: utf8

--- a/misc/packaging/apache/ovirt_log.patch
+++ b/misc/packaging/apache/ovirt_log.patch
@@ -27,17 +27,3 @@ index 8357727..16a0c1c 100644
      level: DEBUG
 -    handlers: [console, file_handler]
 +    handlers: [file_handler]
-diff --git a/misc/packaging/logrotate/ansible-runner-service b/misc/packaging/logrotate/ansible-runner-service
-index 8dcf86b..66082b7 100644
---- a/misc/packaging/logrotate/ansible-runner-service
-+++ b/misc/packaging/logrotate/ansible-runner-service
-@@ -1,7 +1,7 @@
--/var/log/ansible-runner-service.log {
-+/var/log/ovirt-engine/ansible-runner-service.log {
- 	monthly
- 	missingok
- 	compress
--	nocreate
-+	create
- 	rotate 1
- }

--- a/misc/packaging/apache/ovirt_logrotate.patch
+++ b/misc/packaging/apache/ovirt_logrotate.patch
@@ -1,0 +1,32 @@
+diff --git a/logging.yaml b/logging.yaml
+index 8357727..80b2494 100644
+--- a/logging.yaml
++++ b/logging.yaml
+@@ -14,12 +14,10 @@ handlers:
+         stream: ext://sys.stdout
+ 
+     file_handler:
+-        class: logging.handlers.RotatingFileHandler
++        class: logging.handlers.WatchedFileHandler
+         level: DEBUG
+         formatter: simple
+         filename: ansible-runner-service.log
+-        maxBytes: 10485760 # 10MB
+-        backupCount: 20
+         encoding: utf8
+ 
+ root:
+diff --git a/misc/packaging/logrotate/ansible-runner-service b/misc/packaging/logrotate/ansible-runner-service
+index 8dcf86b..66082b7 100644
+--- a/misc/packaging/logrotate/ansible-runner-service
++++ b/misc/packaging/logrotate/ansible-runner-service
+@@ -1,7 +1,7 @@
+-/var/log/ansible-runner-service.log {
++/var/log/ovirt-engine/ansible-runner-service.log {
+ 	monthly
+ 	missingok
+ 	compress
+-	nocreate
++	create
+ 	rotate 1
+ }

--- a/misc/packaging/apache/ovirt_logrotate.patch
+++ b/misc/packaging/apache/ovirt_logrotate.patch
@@ -1,10 +1,17 @@
 diff --git a/logging.yaml b/logging.yaml
-index 8357727..80b2494 100644
+index 8357727..16a0c1c 100644
 --- a/logging.yaml
 +++ b/logging.yaml
-@@ -14,12 +14,10 @@ handlers:
-         stream: ext://sys.stdout
+@@ -7,21 +7,13 @@ formatters:
+         format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
  
+ handlers:
+-    console:
+-        class: logging.StreamHandler
+-        level: DEBUG
+-        formatter: simple
+-        stream: ext://sys.stdout
+-
      file_handler:
 -        class: logging.handlers.RotatingFileHandler
 +        class: logging.handlers.WatchedFileHandler
@@ -16,6 +23,9 @@ index 8357727..80b2494 100644
          encoding: utf8
  
  root:
+     level: DEBUG
+-    handlers: [console, file_handler]
++    handlers: [file_handler]
 diff --git a/misc/packaging/logrotate/ansible-runner-service b/misc/packaging/logrotate/ansible-runner-service
 index 8dcf86b..66082b7 100644
 --- a/misc/packaging/logrotate/ansible-runner-service

--- a/misc/packaging/logrotate/ansible-runner-service
+++ b/misc/packaging/logrotate/ansible-runner-service
@@ -1,7 +1,7 @@
 /var/log/ansible-runner-service.log {
-	monthly
+	weekly
 	missingok
 	compress
-	nocreate
-	rotate 1
+	create
+	rotate 4
 }

--- a/packaging/gunicorn/ovirt_log.patch
+++ b/packaging/gunicorn/ovirt_log.patch
@@ -1,13 +1,43 @@
 diff --git a/logging.yaml b/logging.yaml
-index 8357727..a883306 100644
+index 8357727..16a0c1c 100644
 --- a/logging.yaml
 +++ b/logging.yaml
-@@ -17,7 +17,7 @@ handlers:
-         class: logging.handlers.RotatingFileHandler
+@@ -7,21 +7,13 @@ formatters:
+         format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+ 
+ handlers:
+-    console:
+-        class: logging.StreamHandler
+-        level: DEBUG
+-        formatter: simple
+-        stream: ext://sys.stdout
+-
+     file_handler:
+-        class: logging.handlers.RotatingFileHandler
++        class: logging.handlers.WatchedFileHandler
          level: DEBUG
          formatter: simple
 -        filename: ansible-runner-service.log
 +        filename: /var/log/ovirt-engine/ansible-runner-service.log
-         maxBytes: 10485760 # 10MB
-         backupCount: 20
+-        maxBytes: 10485760 # 10MB
+-        backupCount: 20
          encoding: utf8
+ 
+ root:
+     level: DEBUG
+-    handlers: [console, file_handler]
++    handlers: [file_handler]
+diff --git a/misc/packaging/logrotate/ansible-runner-service b/misc/packaging/logrotate/ansible-runner-service
+index 8dcf86b..66082b7 100644
+--- a/misc/packaging/logrotate/ansible-runner-service
++++ b/misc/packaging/logrotate/ansible-runner-service
+@@ -1,7 +1,7 @@
+-/var/log/ansible-runner-service.log {
++/var/log/ovirt-engine/ansible-runner-service.log {
+ 	monthly
+ 	missingok
+ 	compress
+-	nocreate
++	create
+ 	rotate 1
+ }

--- a/packaging/gunicorn/ovirt_log.patch
+++ b/packaging/gunicorn/ovirt_log.patch
@@ -27,17 +27,3 @@ index 8357727..16a0c1c 100644
      level: DEBUG
 -    handlers: [console, file_handler]
 +    handlers: [file_handler]
-diff --git a/misc/packaging/logrotate/ansible-runner-service b/misc/packaging/logrotate/ansible-runner-service
-index 8dcf86b..66082b7 100644
---- a/misc/packaging/logrotate/ansible-runner-service
-+++ b/misc/packaging/logrotate/ansible-runner-service
-@@ -1,7 +1,7 @@
--/var/log/ansible-runner-service.log {
-+/var/log/ovirt-engine/ansible-runner-service.log {
- 	monthly
- 	missingok
- 	compress
--	nocreate
-+	create
- 	rotate 1
- }


### PR DESCRIPTION
issues:
- when we used logrotate it was not working properly with the filehandler did need to switch to `WatchedFileHandler`
- wrong path in ovirt logrotate 
- after rotating the log was missing fixed it by changing `nocreate` to `create` 
- removed console output so logs are not put to httpd but only to our logs with our logrotate 

@mwperina 