### PR TITLE
Fix ovirt logrotate path

### DIFF
--- a/misc/packaging/logrotate/ansible-runner-service
+++ b/misc/packaging/logrotate/ansible-runner-service
@@ -1,4 +1,4 @@
-/var/log/ansible-runner-service.log {
+/var/log/ovirt-engine/ansible-runner-service.log {
 	weekly
 	missingok
 	compress


### PR DESCRIPTION
Fixes logrotate path for ovirt-engine log
I have noticed this after release 1.0.4 and when building the rpm I added patches for this.
@mwperina  