### PR TITLE
Change artifacts_remove_age for weekly cleanup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ target_user: root
 
 # maximum age of an artifact folder in days
 # set to 0 to disable the automatic removal of old artifact folders
-# artifacts_remove_age: 30
+# artifacts_remove_age: 7
 
 # how frequently the old artifacts should be removed in days
 # artifacts_remove_frequency: 1

--- a/runner_service/configuration.py
+++ b/runner_service/configuration.py
@@ -58,7 +58,7 @@ class Config(object):
 
         # maximum age of an artifact folder in days
         # set to 0 to disable the automatic removal of old artifact folders
-        self.artifacts_remove_age = 30
+        self.artifacts_remove_age = 7
 
         # how frequently the old artifacts should be removed in days
         self.artifacts_remove_frequency = 1


### PR DESCRIPTION
The issue was when we scaled up the usage of the ARS the artifacts folder took really lot of disk space
https://bugzilla.redhat.com/show_bug.cgi?id=1857722
@mwperina 