### PR TITLE
fix apache log permissions

### DIFF
--- a/misc/packaging/apache/ansible-runner-service.spec
+++ b/misc/packaging/apache/ansible-runner-service.spec
@@ -65,6 +65,9 @@ install -m 644 ./misc/packaging/logrotate/ansible-runner-service %{buildroot}%{_
 
 install -m 644 ./ansible_runner_service.py %{buildroot}%{python3_sitelib}/runner_service
 
+%post
+[[ -f /var/log/ovirt-engine/ansible-runner-service.log ]] && chcon -t httpd_log_t /var/log/ovirt-engine/ansible-runner-service.log
+
 %files -n %{srcname}
 %{_bindir}/ansible_runner_service
 %{python3_sitelib}/*


### PR DESCRIPTION
When there was a log from an older version of ARS it had wrong permission on apache.
Now it forcefully changes it to correct.
@mwperina @dangel101 
