### PR TITLE
Move sh to bash

### DIFF
--- a/misc/nginx/generate_certs.sh
+++ b/misc/nginx/generate_certs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Certificates data, password and placement are customizable in this file
 source ./certificates_data.custom

--- a/misc/nginx/generate_client_cert.sh
+++ b/misc/nginx/generate_client_cert.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Certificates data, password and placement are customizable in this file
 source ./certificates_data.custom


### PR DESCRIPTION
source is bash built-in and it does not work in pure shell, and the scripts to generate certificates fail on most linux distributions.