### PR TITLE
Add proper logging when decoding JSON has failed

### DIFF
--- a/runner_service/controllers/playbooks.py
+++ b/runner_service/controllers/playbooks.py
@@ -145,8 +145,12 @@ def _run_playbook(playbook_name, tags=None):
                           "Invalid content-type({}). Use application/" \
                           "json".format(request.content_type)
         return r
-
-    vars = request.get_json()
+    try:
+        vars = request.get_json()
+    except Exception as e:
+        r.status, r.msg = "INVALID", "Failed to decode JSON object: {}".format(e)
+        logger.error(r)
+        return r
     filter = request.args.to_dict()
     if not all([_k in valid_filter for _k in filter.keys()]):
         r.status, r.msg = "INVALID", "Bad request, supported " \


### PR DESCRIPTION
When the request contains data that cannot be parsed as JSON (for example when user adds quotes, thus resulting with double quotes surrounded by double quotes), there's no indication for it
This patch adds a try clause and an error message so that such cases will be logged properly and be easier to fix