### PR TITLE
add ignore for partial.json.tmp

### DIFF
--- a/runner_service/services/jobs.py
+++ b/runner_service/services/jobs.py
@@ -30,7 +30,7 @@ ignored_events = [
 def get_event_info(event_path):
     event_fname = os.path.basename(event_path)
 
-    if event_fname.endswith("-partial.json"):
+    if event_fname.endswith("-partial.json") or event_fname.endswith("-partial.json.tmp"):
         logger.debug("Skipping partial event file: {}".format(event_fname))
         return None
 


### PR DESCRIPTION
Hi,
I found an issue that the ARS was trying to read the partial json tmp and at that moment it was already removed, this PR fixes the issue by ignoring all those tmp files.

Exception:
```
 Exception in thread Thread-479:
 Traceback (most recent call last):
   File "/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
     self.run()
   File "/usr/lib64/python3.6/threading.py", line 864, in run
     self._target(*self._args, **self._kwargs)
   File "/usr/lib/python3.6/site-packages/runner_service/services/jobs.py", line 133, in scan_event_data
     event_info = get_event_info(event_path)
   File "/usr/lib/python3.6/site-packages/runner_service/services/jobs.py", line 37, in get_event_info
     with open(event_path, 'r') as event_fd:
 FileNotFoundError: [Errno 2] No such file or directory: '/usr/share/ovirt-engine/ansible-runner-service-project/artifacts/6b215a3a-5f3d-11eb-825e-001a4a013f59/job_events/3309c4c4-3485-4e75-bf29-fcc88b6af399-partial.json.tmp'
```