### PR TITLE
fix: PyYAML  load expects additional Loader

### DIFF
--- a/runner_service/configuration.py
+++ b/runner_service/configuration.py
@@ -106,7 +106,7 @@ class Config(object):
 
         try:
             with open(self.config_file, "r") as _cfg:
-                local_config = yaml.load(_cfg.read())
+                local_config = yaml.load(_cfg.read(), Loader=yaml.SafeLoader)
         except yaml.YAMLError as exc:
             logger.critical("ERROR: YAML error in configuration "
                             "file: {}".format(exc))


### PR DESCRIPTION
## Error

Upon installing the requirements in a `virtualenv` and running `python ansible_runner_service.py`, one stumbles upon and error related to PyYAML. Current version installed on system for `PyYAML` is `6.0` and it requires and additional positional argument when calling `.load`.